### PR TITLE
Added given, when, then keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ The following new block definitions are utilized by Demonstrate:
 
 - **`before`/`after`** — A block of source code that will be included at the start or end of each test respectively in the current and nested `describe`/`context` blocks.
 
-- **`describe`/`context`** — `describe` and `context` are aliases for eachother. Specifies a new scope of tests which can contain a `before` and/or `after` block, nested `describe`/`context` blocks, and `it`/`test` blocks. These translate to Rust `mod` blocks, but also allow for shared test properties to be defined such as tests having outer attributes, being `async`, and having `Return<()>` types.
+- **`describe`/`context`/`given`/`when`** — `describe`, `context`, `given`, `when` are aliases for eachother. Specifies a new scope of tests which can contain a `before` and/or `after` block, nested `describe`/`context` blocks, and `it`/`test` blocks. These translate to Rust `mod` blocks, but also allow for shared test properties to be defined such as tests having outer attributes, being `async`, and having `Return<()>` types.
 
-- **`it`/`test`** — `it` and `test` are aliases for eachother. Represents one test that translate to a Rust unit test.
+- **`it`/`test`/`then`** — `it`, `test` and `then` are aliases for eachother. Represents one test that translate to a Rust unit test.
 
 <br />
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -16,10 +16,13 @@ mod keyword {
     // Are aliases for eachother:
     custom_keyword!(describe);
     custom_keyword!(context);
+    custom_keyword!(given);
+    custom_keyword!(when);
 
     // Are aliases for eachother:
     custom_keyword!(it);
     custom_keyword!(test);
+    custom_keyword!(then);
 }
 
 /// All the root `Describe` blocks defined in the current `demonstrate!` instance
@@ -53,9 +56,16 @@ impl Parse for Block {
         let _async_token = fork.parse::<Option<Token![async]>>()?;
 
         let lookahead = fork.lookahead1();
-        if lookahead.peek(keyword::it) || lookahead.peek(keyword::test) {
+        if lookahead.peek(keyword::it)
+            || lookahead.peek(keyword::test)
+            || lookahead.peek(keyword::then)
+        {
             Ok(Block::Test(input.parse::<Test>()?))
-        } else if lookahead.peek(keyword::describe) || lookahead.peek(keyword::context) {
+        } else if lookahead.peek(keyword::describe)
+            || lookahead.peek(keyword::context)
+            || lookahead.peek(keyword::given)
+            || lookahead.peek(keyword::when)
+        {
             Ok(Block::Describe(input.parse::<Describe>()?))
         } else {
             Err(lookahead.error())


### PR DESCRIPTION
In [BDD testing](https://www.bddtesting.com/), it's common to use the words "given", "when" and "then" to describe the test units.
This patch adds:
+ `given` and `when` as aliases of `describe`
+ `then` as an alias to `it`